### PR TITLE
Fix Starfish installation on travis.ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 python:
+    - "3.4"
     - "3.5"
     - "3.6"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,21 +31,18 @@ install:
   # Install Starfish
   - travis_retry conda install --yes scipy matplotlib Cython h5py scikit-learn astropy pyyaml pytest cython emcee
   - pip install corner
-  - mkdir Starfish_dir
-  - travis_retry git clone https://github.com/iancze/Starfish.git starfish_dir
-  - travis_retry pip install -r starfish_dir/requirements.txt
-  - rm Starfish_dir/tests -rf   # to not test Starfish
-  # - python -c "import Starfish"
-  - cd starfish_dir
+  - mkdir ../starfish_dir
+  - travis_retry git clone https://github.com/iancze/Starfish.git ../starfish_dir
+  - travis_retry pip install -r ../starfish_dir/requirements.txt
+  #- rm starfish_dir/tests -rf   # to not test Starfish
+  - cd ../starfish_dir
   - python setup.py build_ext --inplace
   - python setup.py develop
   - python -c "import Starfish"
   - python -c "from Starfish.covariance import get_dense_C"
-  - cd ..
-  - conda list
-  - pip list
   - export PYTHONPATH=$HOME/Starfish_dir/:$HOME/Starfish_dir/Starfish/:$HOME/Starfish_dir/scripts/:$PYTHONPATH
   - export PATH=$HOME/Starfish_dir/:$HOME/Starfish_dir/Starfish/:$HOME/Starfish_dir/scripts/:$PATH
+  - cd $HOME
   # - pip install https://github.com/iancze/Starfish/archive/master.zip
   - python -c "import Starfish"
   - python -c "from Starfish.covariance import get_dense_C"

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,15 +25,14 @@ cache:
     - $HOME/.cache/pip
 
 install:
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy astropy matplotlib numba llvmlite multiprocess ephem tqdm joblib
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION astropy ephem joblib llvmlite matplotlib multiprocess numba numpy scipy tqdm
   - source activate test-environment
 
   # Install Starfish
-  - travis_retry conda install --yes scipy matplotlib Cython h5py scikit-learn astropy pyyaml pytest cython emcee
-  - pip install corner
   - cd $HOME
   - travis_retry git clone https://github.com/iancze/Starfish.git
   - cd Starfish
+  - travis_retry conda install --yes astropy cython emcee h5py matplotlib pytest pyyaml scikit-learn scipy
   - travis_retry pip install -r requirements.txt
   - python setup.py build_ext --inplace
   - python setup.py develop
@@ -46,10 +45,9 @@ install:
 
   # Clone spectrum_overload
   - travis_retry pip install https://github.com/jason-neal/spectrum_overload/archive/master.zip
-  # Import Get_filenames.py
+  # Wget Get_filenames.py
   - wget https://raw.githubusercontent.com/jason-neal/equanimous-octo-tribble/master/Get_filenames.py
   - python setup.py install
-
 
 script:
     pytest --cov=. --cov-report term-missing --durations 5

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,9 +46,10 @@ install:
 
   # Clone spectrum_overload
   - travis_retry pip install https://github.com/jason-neal/spectrum_overload/archive/master.zip
-
+  # Import Get_filenames.py
+  - wget https://raw.githubusercontent.com/jason-neal/equanimous-octo-tribble/master/Get_filenames.py
   - python setup.py install
-  - python -c "import Starfish"
+
 
 script:
     pytest --cov=. --cov-report term-missing --durations 5

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,8 +37,8 @@ install:
   - rm Starfish_dir/tests -rf   # to not test Starfish
   # - python -c "import Starfish"
   - cd starfish_dir
-#  - python setup.py build_ext
-  - python setup.py install
+  - python setup.py build_ext --in-place
+  - python setup.py develop
   - python -c "import Starfish"
   - python -c "from Starfish.covariance import get_dense_C"
   - cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ install:
   - rm Starfish_dir/tests -rf   # to not test Starfish
   # - python -c "import Starfish"
   - cd starfish_dir
-  - python setup.py build_ext --inplace
+  - python setup.py build_ext
   - python setup.py install
   - python -c "import Starfish"
   - python -c "from Starfish.covariance import get_dense_C"

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ install:
   - rm Starfish_dir/tests -rf   # to not test Starfish
   # - python -c "import Starfish"
   - cd starfish_dir
-  - python setup.py build_ext --in-place
+  - python setup.py build_ext --inplace
   - python setup.py develop
   - python -c "import Starfish"
   - python -c "from Starfish.covariance import get_dense_C"

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,11 +30,12 @@ install:
 
   # Install Starfish
   - travis_retry conda install --yes scipy matplotlib Cython h5py scikit-learn astropy pyyaml pytest cython emcee corner
-  - travis_retry git clone  https://github.com/iancze/Starfish.git
-  - travis_retry pip install -r Starfish/requirements.txt
-  - rm Starfish/tests -rf   # to not test Starfish
+  - mkdir Starfish_dir
+  - travis_retry git clone https://github.com/iancze/Starfish.git starfish_dir
+  - travis_retry pip install -r starfish_dir/requirements.txt
+  - rm Starfish_dir/tests -rf   # to not test Starfish
   - python -c "import Starfish"
-  - cd Starfish
+  - cd starfish_dir
   - python setup.py build_ext --inplace
   - python setup.py install
   - python -c "import Starfish"

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,13 +32,16 @@ install:
   - travis_retry git clone  https://github.com/iancze/Starfish.git
   - travis_retry pip install -r Starfish/requirements.txt
   - rm Starfish/tests -rf   # to not test Starfish
+  - python -c "import Starfish"
   - cd Starfish
   - python setup.py build_ext --inplace
   - python setup.py install
+  - python -c "import Starfish"
   - cd ..
   - export PYTHONPATH=$HOME/Starfish/:$HOME/Starfish/Starfish/:$HOME/Starfish/scripts/:$PYTHONPATH
   - export PATH=$HOME/Starfish/:$HOME/Starfish/Starfish/:$HOME/Starfish/scripts/:$PATH
   # - pip install https://github.com/iancze/Starfish/archive/master.zip
+  - python -c "import Starfish"
 
   # Now install companion simulations
   # Test requirements
@@ -49,6 +52,7 @@ install:
   - travis_retry pip install https://github.com/jason-neal/spectrum_overload/archive/master.zip
 
   - travis_retry python setup.py install
+  - python -c "import Starfish"
 
 script:
     pytest --cov=. --cov-report term-missing --durations 5

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,8 @@ install:
   - source activate test-environment
 
   # Install Starfish
-  - travis_retry conda install --yes scipy matplotlib Cython h5py scikit-learn astropy pyyaml pytest cython emcee corner
+  - travis_retry conda install --yes scipy matplotlib Cython h5py scikit-learn astropy pyyaml pytest cython emcee
+  - pip install corner
   - mkdir Starfish_dir
   - travis_retry git clone https://github.com/iancze/Starfish.git starfish_dir
   - travis_retry pip install -r starfish_dir/requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,8 +42,10 @@ install:
   - python -c "import Starfish"
   - python -c "from Starfish.covariance import get_dense_C"
   - cd ..
-  - export PYTHONPATH=$HOME/Starfish/:$HOME/Starfish/Starfish/:$HOME/Starfish/scripts/:$PYTHONPATH
-  - export PATH=$HOME/Starfish/:$HOME/Starfish/Starfish/:$HOME/Starfish/scripts/:$PATH
+  - conda list
+  - pip list
+  - export PYTHONPATH=$HOME/Starfish_dir/:$HOME/Starfish_dir/Starfish/:$HOME/Starfish_dir/scripts/:$PYTHONPATH
+  - export PATH=$HOME/Starfish_dir/:$HOME/Starfish_dir/Starfish/:$HOME/Starfish_dir/scripts/:$PATH
   # - pip install https://github.com/iancze/Starfish/archive/master.zip
   - python -c "import Starfish"
   - python -c "from Starfish.covariance import get_dense_C"

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ install:
   - rm Starfish_dir/tests -rf   # to not test Starfish
   # - python -c "import Starfish"
   - cd starfish_dir
-  - python setup.py build_ext
+#  - python setup.py build_ext
   - python setup.py install
   - python -c "import Starfish"
   - python -c "from Starfish.covariance import get_dense_C"

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,24 +31,16 @@ install:
   # Install Starfish
   - travis_retry conda install --yes scipy matplotlib Cython h5py scikit-learn astropy pyyaml pytest cython emcee
   - pip install corner
-  - mkdir ../starfish_dir
-  - travis_retry git clone https://github.com/iancze/Starfish.git ../starfish_dir
+  - cd $HOME
+  - travis_retry git clone https://github.com/iancze/Starfish.git
+  - cd Starfish
   - travis_retry pip install -r ../starfish_dir/requirements.txt
-  #- rm starfish_dir/tests -rf   # to not test Starfish
-  - cd ../starfish_dir
   - python setup.py build_ext --inplace
   - python setup.py develop
-  - python -c "import Starfish"
-  - python -c "from Starfish.covariance import get_dense_C"
-  - export PYTHONPATH=$HOME/Starfish_dir/:$HOME/Starfish_dir/Starfish/:$HOME/Starfish_dir/scripts/:$PYTHONPATH
-  - export PATH=$HOME/Starfish_dir/:$HOME/Starfish_dir/Starfish/:$HOME/Starfish_dir/scripts/:$PATH
-  - cd $HOME
-  # - pip install https://github.com/iancze/Starfish/archive/master.zip
-  - python -c "import Starfish"
-  - python -c "from Starfish.covariance import get_dense_C"
 
   # Now install companion simulations
   # Test requirements
+  - cd $TRAVIS_BUILD_DIR               # Return to original directory
   - travis_retry pip install -r test_requirements.txt
   - travis_retry pip install -r requirements.txt
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ install:
   - cd $HOME
   - travis_retry git clone https://github.com/iancze/Starfish.git
   - cd Starfish
-  - travis_retry pip install -r ../starfish_dir/requirements.txt
+  - travis_retry pip install -r requirements.txt
   - python setup.py build_ext --inplace
   - python setup.py develop
 
@@ -47,7 +47,7 @@ install:
   # Clone spectrum_overload
   - travis_retry pip install https://github.com/jason-neal/spectrum_overload/archive/master.zip
 
-  - travis_retry python setup.py install
+  - python setup.py install
   - python -c "import Starfish"
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,16 +35,18 @@ install:
   - travis_retry git clone https://github.com/iancze/Starfish.git starfish_dir
   - travis_retry pip install -r starfish_dir/requirements.txt
   - rm Starfish_dir/tests -rf   # to not test Starfish
-  - python -c "import Starfish"
+  # - python -c "import Starfish"
   - cd starfish_dir
   - python setup.py build_ext --inplace
   - python setup.py install
   - python -c "import Starfish"
+  - python -c "from Starfish.covariance import get_dense_C"
   - cd ..
   - export PYTHONPATH=$HOME/Starfish/:$HOME/Starfish/Starfish/:$HOME/Starfish/scripts/:$PYTHONPATH
   - export PATH=$HOME/Starfish/:$HOME/Starfish/Starfish/:$HOME/Starfish/scripts/:$PATH
   # - pip install https://github.com/iancze/Starfish/archive/master.zip
   - python -c "import Starfish"
+  - python -c "from Starfish.covariance import get_dense_C"
 
   # Now install companion simulations
   # Test requirements

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,26 +27,26 @@ install:
   - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy astropy matplotlib numba llvmlite multiprocess ephem tqdm joblib
   - source activate test-environment
 
- # Test requirements
-  - travis_retry pip install -r test_requirements.txt
-  - travis_retry pip install -r requirements.txt
-
-  # Clone spectrum_overload
-  - travis_retry pip install https://github.com/jason-neal/spectrum_overload/archive/master.zip
-
   # Install Starfish
-  - travis_retry conda install h5py cython pyyaml scikit-learn emcee corner
+  - travis_retry conda install --yes scipy matplotlib Cython h5py scikit-learn astropy pyyaml pytest cython emcee corner
   - travis_retry git clone  https://github.com/iancze/Starfish.git
+  - travis_retry pip install -r Starfish/requirements.txt
+  - rm Starfish/tests -rf   # to not test Starfish
   - cd Starfish
-  - conda install --yes scipy matplotlib Cython h5py scikit-learn astropy pyyaml pytest   # from starfish's .travis.yml
-  - travis_retry pip install -r requirements.txt
-  - rm tests -rf   # to not test Starfish
   - python setup.py build_ext --inplace
   - python setup.py install
   - cd ..
   - export PYTHONPATH=$HOME/Starfish/:$HOME/Starfish/Starfish/:$HOME/Starfish/scripts/:$PYTHONPATH
   - export PATH=$HOME/Starfish/:$HOME/Starfish/Starfish/:$HOME/Starfish/scripts/:$PATH
-# - pip install https://github.com/iancze/Starfish/archive/master.zip
+  # - pip install https://github.com/iancze/Starfish/archive/master.zip
+
+  # Now install companion simulations
+  # Test requirements
+  - travis_retry pip install -r test_requirements.txt
+  - travis_retry pip install -r requirements.txt
+
+  # Clone spectrum_overload
+  - travis_retry pip install https://github.com/jason-neal/spectrum_overload/archive/master.zip
 
   - travis_retry python setup.py install
 


### PR DESCRIPTION
Rearrange the travis.ci file a little.

- Move Starfish to $HOME/Starfish
- Use `develop` instead of `install`.
- wget Get_filenames.py file.